### PR TITLE
force ITGmania 0.8 at minimum

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -393,10 +393,7 @@ local t = Def.ActorFrame {
 		end
 
 		-- Reload songs, feature for ITGmania only
-		local product = VersionNumber()
-		if product:find("ITGmania") then
-			table.insert(wheel_options, {"TakeABreather", "LoadNewSongs"})
-		end
+		table.insert(wheel_options, {"TakeABreather", "LoadNewSongs"})
 
 		if not GAMESTATE:IsCourseMode() then
 			if ThemePrefs.Get("KeyboardFeatures") then				

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -574,6 +574,7 @@ EvalAllowUpDownArrows=Allow Up/Down Arrows\nOn Evaluation
 AlwaysMergeScores=Always Merge Scores
 PreloadGrades=Preload Folder Grades
 KeyboardFeatures=Keyboard Features
+RescoreEarlyHits=Enable Rescoring Early Hits
 
 # Customize Profile Options
 ProfileCardInfo=Profile Card View
@@ -759,6 +760,7 @@ OnlyDedicatedMenuButtons=• Use Gameplay Buttons - Navigate through the game us
 ThreeKeyNavigation=Enable this if you only have three MenuButtons per player (e.g. a traditional DDR arcade cabinet).  Some UI elements will change to reflect this.\n\nWith this enabled, you can save screenshots at Evaluation by simultaneously pressing &MENULEFT; and &MENURIGHT;.
 ArcadeOptionsNavigation=This impacts how option menus are navigated.\n\n• StepMania Style - &START; button moves to end.\n\n• Arcade Style - &START; button moves to next option line.
 KeyboardFeatures=Turn keyboard features on or off.\n\nTurning this feature on enables:\n- Songwheel Song Search\n- Ctrl+R Quick Restart
+RescoreEarlyHits=Allow early hits of Decents ands Way Offs to be rescored to better judgments.\n\nChanging this setting will require a game restart to take effect.
 InputDebounceTime=Time that a panel takes to de-press.  Use this to deal with ghost steps that occur a few milliseconds after a real step.
 AxisFix=Set this to "On" if you use a USB adapter to connect your dance pad and certain jumps (for example, Up-Down jumps, Left-Right jumps, etc.) always register as "Miss".  This may fix the issue.
 #'
@@ -918,6 +920,7 @@ AllowScreenSelectProfile=This should be 'No' for public machines.
 AllowDanceSolo=This should be 'No' unless you have a 6-panel dance pad.
 CasualMaxMeter=10 is about right for most public machines.
 UseImageCache=There is no need to turn this on if you never use Casual Mode.
+RescoreEarlyHits=Right now this is disabled as early Faults aren't accounted for properly yet.
 
 # Appearance Options
 ShowLyrics=Hide

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # Waterfall Expanded-suki
- *A modified fork of SteveReen / zarzob's Waterfall theme for StepMania 5 / ITGmania*
+
+_A modified fork of SteveReen / zarzob's Waterfall theme for StepMania 5 / ITGmania_
+
+Requires ITGmania 0.8.0 or newer.
 
 Based on Waterfall Expanded v0.7.8
 
 Features:
+
 - Performance improvements all around
 - Lighter weight background video for lower resource consumption
 - Backported ScreenSelectMusicCasual overlay\Setup.lua from Simply Love

--- a/Scripts/99 SL-ThemePrefs.lua
+++ b/Scripts/99 SL-ThemePrefs.lua
@@ -94,7 +94,11 @@ SL_CustomPrefs.Get = function()
 			Choices =  { THEME:GetString("ThemePrefs","Yes"), THEME:GetString("ThemePrefs", "No") },
 			Values	= { true, false }
 		},
-
+        RescoreEarlyHits = {
+            Default = false,
+            Choices = { THEME:GetString("ThemePrefs", "Yes"), THEME:GetString("ThemePrefs", "No") },
+            Values = { true, false }
+        },
 		-- - - - - - - - - - - - - - - - - - - -
 		-- Enable/Disable Certain Screens
 		AllowScreenSelectProfile =

--- a/Scripts/SL_Init.lua
+++ b/Scripts/SL_Init.lua
@@ -216,6 +216,7 @@ SL = {
 			RegenComboAfterMiss=5,
 			MaxRegenComboAfterMiss=10,
 			MinTNSToHideNotes="TapNoteScore_W3",
+			MinTNSToScoreNotes = ThemePrefs.Get("RescoreEarlyHits") and "TapNoteScore_W3" or "TapNoteScore_None",
 			HarshHotLifePenalty=true,
 
 			PercentageScoring=true,
@@ -237,6 +238,7 @@ SL = {
 			RegenComboAfterMiss=5,
 			MaxRegenComboAfterMiss=5,
 			MinTNSToHideNotes="TapNoteScore_W4",
+			MinTNSToScoreNotes = ThemePrefs.Get("RescoreEarlyHits") and "TapNoteScore_W4" or "TapNoteScore_None",
 			HarshHotLifePenalty=false,
 
 			PercentageScoring=true,

--- a/metrics.ini
+++ b/metrics.ini
@@ -1128,7 +1128,7 @@ Fallback="ScreenOptionsServiceChild"
 OptionRowNormalMetricsGroup="OptionRowSimplyLoveOptions"
 
 LineNames=(function() \
-   	local lines = "CustomFailSet,CreditStacking,MusicWheelStyle,MusicWheelSpeed,SelectProfile,HideStockNoteSksins,EvalUpDown,AlwaysMerge,PreloadGrades,KeyboardFeatures" \
+   	local lines = "CustomFailSet,CreditStacking,MusicWheelStyle,MusicWheelSpeed,SelectProfile,HideStockNoteSksins,EvalUpDown,AlwaysMerge,PreloadGrades,KeyboardFeatures,RescoreEarlyHits" \
    	if Sprite.LoadFromCached ~= nil then lines = lines .. ",UseImageCache" end \
       return lines \
 end)()
@@ -1152,6 +1152,7 @@ LinePreloadGrades="lua,ThemePrefsRows.GetRow('PreloadGrades')"
 
 LineUseImageCache="lua,ThemePrefsRows.GetRow('UseImageCache')"
 LineKeyboardFeatures="lua,ThemePrefsRows.GetRow('KeyboardFeatures')"
+LineRescoreEarlyHits="lua,ThemePrefsRows.GetRow('RescoreEarlyHits')"
 
 # Customize Profile Menu
 [ScreenCustomProfile]


### PR DESCRIPTION
This will be required for future changes (like beat bars and ITGmania's GrooveStats integration).

This PR also adds the option for judgements to be recalculated as well as setting the correct minimum judgement for Waterfall (otherwise OKs would be recalc'd). I've set this to off by default tho, since using recalcs right now is effectively cheating (you get to rescore but don't get a lifebar hit).